### PR TITLE
Ignore empty project list

### DIFF
--- a/cvetracker/git_scanner.py
+++ b/cvetracker/git_scanner.py
@@ -399,6 +399,10 @@ class DebProjectParser(GitProjectParser):
         if product_data['type'] != 'deb':
             return
 
+        if not self.repo.import_project(self.project_config['project'],
+                                        branch=branch):
+            return
+
         self.repo.import_project(self.project_config['project'],
                                  branch=branch)
         project_data['commit'] = self.repo._.head.commit.hexsha


### PR DESCRIPTION
Otherwise script will throw an error:
TypeError: 'NoneType' object is not iterable