### PR TITLE
Ignore unavailable project

### DIFF
--- a/cvetracker/git_scanner.py
+++ b/cvetracker/git_scanner.py
@@ -73,6 +73,7 @@ class GitRepo(object):
             self.deep_clean(branch)
 
         # self._.git.pull()
+        return True
 
     def remote(self, name, url=None):
         remote = getattr(self._.remotes, name, None)
@@ -408,7 +409,7 @@ class DebProjectParser(GitProjectParser):
             return
 
         if not self.repo.import_project(self.project_config['project'],
-                                         branch=branch):
+                                        branch=branch):
             return
 
         project_data['commit'] = self.repo._.head.commit.hexsha


### PR DESCRIPTION
Otherwise script will throw an error:
TypeError: 'NoneType' object is not iterable